### PR TITLE
support High Sierra

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ To play:
 * Clone the repo
 * Run `flap.py first-time-setup` (`flap.py` has no dependencies)
 * Open Finder and navigate to the directory where you put this code
-* Open the directory `buf1` and sort the window by "Date Modified." Do the same thing with `buf2`.
+* Set the display mode to list view
+* Open the directory `buf1` and sort the window by "Date Modified", ascending (arrow pointing up). Do the same thing with `buf2`.
     * The game will look really weird if you don't do this!!
 * Run `osascript ./flappy-dird.applescript`
 * Find the Finder window you opened, play the game.

--- a/flap.py
+++ b/flap.py
@@ -12,6 +12,7 @@ import argparse
 import random
 from collections import namedtuple
 import string
+import platform
 
 WIDTH = 15
 HEIGHT = 20
@@ -70,6 +71,17 @@ for ad in _AD_TEXTS:
     ad.insert(0, "UU✈️")
     AD_TEXTS.append(ad)
 AD_STARTING_PADDING_SPACES = 70
+
+# APFS supports Unicode 12.0 since ~Catalina 10.15.1
+if tuple(map(int, platform.mac_ver()[0].split('.'))) < (10, 15, 1):
+    # bummer, we have to use some old emoji that only kinda sorta look like what we wanted
+    BLUE   = "🆒"
+    GREEN  = "✅"
+    WHITE  = "⬜"
+    BROWN =  "🏾" # HACK: this is supposed to be a skin tone modifier
+    YELLOW = "📒"
+    ORANGE = "📙"
+    RED    = X
 
 PipePair = namedtuple("PipePair", ["x", "midpoint", "space_between_top_and_bottom"])
 def generate_random_pipe(x):

--- a/flap.py
+++ b/flap.py
@@ -367,7 +367,7 @@ def check_for_collision(state):
 
 def get_last_opened(state):
     buffer = displayed_buffer(state)
-    command = f"mdls -attr kMDItemLastUsedDate {buffer}"
+    command = f"mdls -name kMDItemLastUsedDate {buffer}"
     return subprocess.check_output(command.split()).strip().decode("utf-8")
 
 def await_command(args):


### PR DESCRIPTION
This fixes #4 and fixes #5. Also, fix a misunderstanding I had with the instructions that caused the game to be upside down the first time I got it working.

Note: the game runs at only about 2 FPS on my machine (a 2013 Macbook Air). But it is playable (I mean... sort of).

Version check is based on [this SO comment](https://stackoverflow.com/questions/9352753/which-unicode-versions-are-supported-in-which-os-x-and-ios-versions#comment130727918_38442010), although the cited page doesn't actually specify the Unicode version, but [this video](https://www.youtube.com/watch?v=XcLHUsr4_Mk) lists the new emoji and spot-checking [yawning face](https://emojipedia.org/yawning-face) it does appear to be Unicode 12.0.

The root cause of #4 is that APFS won't allow unassigned Unicode characters in filenames. You would think they would freeze the filesystem at a particular Unicode version to avoid back-compat issues (like, you can create a [file](https://alexburka.com/🟦.png) on newer macOS that can't be transferred to older macOS), and that's what they claimed to do in the documentation, but apparently they... didn't. I find it extremely funny that Flappy Dird is how I learned this fun fact.

The backup emoji that I found are not the best, especially YELLOW and ORANGE, feel free to check for better options. High Sierra supports Unicode version 10, I believe.

For #5, at some point `-attr` was added as a synonym for `-name` to `mdls`, and they changed the `--help` text but not the man page. Hopefully `-name` still works on newest macOS, but you'll have to verify and if not we'll need to add another version check.